### PR TITLE
Fixed: pkg_resources is deprecated

### DIFF
--- a/sentry_mattermost/__init__.py
+++ b/sentry_mattermost/__init__.py
@@ -1,5 +1,6 @@
+import importlib.metadata
+
 try:
-    VERSION = __import__('pkg_resources') \
-        .get_distribution('sentry-mattermost').version
+    VERSION = importlib.metadata.version('sentry-mattermost')
 except Exception as e:
     VERSION = 'unknown'


### PR DESCRIPTION
DeprecationWarning:
```
/.venv/lib/python3.13/site-packages/sentry_mattermost/__init__.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  VERSION = __import__('pkg_resources') \
```

New syntax https://setuptools.pypa.io/en/latest/pkg_resources.html